### PR TITLE
Enable export of compilation commands

### DIFF
--- a/config/bebop2/kcc/set-vars.cmake
+++ b/config/bebop2/kcc/set-vars.cmake
@@ -33,3 +33,7 @@
 
 set(PSP ${PROJECT_SOURCE_DIR}/core/psp/kcc)
 set(OSAL ${PROJECT_SOURCE_DIR}/core/osal/posix-fast)
+
+# Enable this setting during RV-Match development to easily get the precise KCC
+# command line needed to compile a troublesome file.
+set(CMAKE_EXPORT_COMPILE_COMMANDS On)


### PR DESCRIPTION
This sets a CMake flag in our configuration that provides easy access to the exact invocation of kcc that the build system will use for each source file.

Doing so will make it much easier to extract and test individual problematic cases.